### PR TITLE
Add a `protocol` kwarg to `encrypt()` method to select between MPC an…

### DIFF
--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -205,3 +205,23 @@ def test_complex_model(workers):
 
     ## Forward on the remote model
     pred = model_net(tensor_remote)
+
+
+def test_encrypt_decrypt(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, base=10)
+    x_decrypted = x_encrypted.decrypt()
+    assert torch.all(torch.eq(x_decrypted, x))
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james)
+    x_decrypted = x_encrypted.decrypt()
+    assert torch.all(torch.eq(x_decrypted, x))
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
+    public, private = syft.frameworks.torch.he.paillier.keygen()
+    x_encrypted = x.encrypt(protocol="paillier", public_key=public)
+    x_decrypted = x_encrypted.decrypt(protocol="paillier", private_key=private)
+    assert torch.all(torch.eq(x_decrypted, x))

--- a/test/torch/tensors/test_paillier.py
+++ b/test/torch/tensors/test_paillier.py
@@ -11,9 +11,9 @@ def test_encrypt_and_decrypt():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = x.decrypt(pri)
+    y = x.decrypt(protocol="paillier", private_key=pri)
 
     assert (x_tensor == y).all()
 
@@ -26,9 +26,9 @@ def test_encrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x + x).decrypt(pri)
+    y = (x + x).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -41,9 +41,9 @@ def test_encrypted_decrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x + x_tensor).decrypt(pri)
+    y = (x + x_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -56,9 +56,9 @@ def test_decrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x_tensor + x).decrypt(pri)
+    y = (x_tensor + x).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -68,12 +68,12 @@ def test_encrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x - y).decrypt(pri)
+    z = (x - y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -83,12 +83,12 @@ def test_encrypted_decrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x - y_tensor).decrypt(pri)
+    z = (x - y_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -98,12 +98,12 @@ def test_decrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor - y).decrypt(pri)
+    z = (x_tensor - y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -113,12 +113,12 @@ def test_encrypted_decrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x * y_tensor).decrypt(pri)
+    z = (x * y_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor * y_tensor) == z).all()
 
@@ -128,12 +128,12 @@ def test_decrypted_encrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor * y).decrypt(pri)
+    z = (x_tensor * y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor * y_tensor) == z).all()
 
@@ -143,12 +143,12 @@ def test_encrypted_decrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x.mm(y_tensor)).decrypt(pri)
+    z = (x.mm(y_tensor)).decrypt(protocol="paillier", private_key=pri)
 
     assert (z == 12).all()
 
@@ -158,11 +158,11 @@ def test_decrypted_encrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([[1, 2, 3]])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([[2], [2], [2]])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor.mm(y)).decrypt(pri)
+    z = (x_tensor.mm(y)).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor.mm(y_tensor)) == z).all()


### PR DESCRIPTION
…d Paillier HE (#3234)

* Implement MPC as default

* Remove Paillier condition. Only MPC
Checkout to earlier commit for version with both

* Add functionality to call either properly

* Test cases for encrypt method

* Docstrings added

* Format using Black

* Update function calls in test_native.py

* Cover edge case in test
?

* Suggestions incorporated

* Simpler Code
Thanks to @Jasopaum

* Basic decrypt method

* Doc strings

* Explicit call for paillier